### PR TITLE
Update and upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ node-red-contrib-os
 
 These nodes utilize the [Node.js OS Library][2] to obtain basic operating-system related utility functions.
 
-#Install
+# Install
 
 Run the following command in the root directory of your Node-RED install
 
@@ -55,15 +55,15 @@ Returns an array containing the 1, 5, and 15 minute load averages.
 
 The load average is a measure of system activity, calculated by the operating system and expressed as a fractional number. As a rule of thumb, the load average should ideally be less than the number of logical CPUs in the system.
 
-The load average is a very UNIX-y concept; there is no real equivalent on Windows platforms. That is why this node always returns [0, 0, 0] on Windows.
+The load average is a very UNIX-y concept; there is no real equivalent on Windows platforms. That is why on Windows, loadavg-windows is used to have an approximation of the average load.
 
 ### Memory
 
 Use this node to query the system''s memory.
 
-Returns the total amount of system memory in bytes.
+Returns the total amount of system memory in bytes, kilobytes, megabytes or gigabytes.
 
-Returns the amount of free system memory in bytes.
+Returns the amount of free system memory in bytes, kilobytes, megabytes or gigabytes.
 
 Returns the memory in use as a percentage.
 

--- a/os/os.html
+++ b/os/os.html
@@ -183,14 +183,23 @@
     <div class="form-row">
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
-    </div>  
+    </div> 
+	<div class="form-row">
+		<label for="node-input-scale"><i class="icon-tag"></i> Scale</label>
+		<select type="text" id="node-input-scale" placeholder="scale">
+			<option value="Byte">Byte</option>
+			<option value="Kilobyte">Kilobyte (KB)</option>
+			<option value="Megabyte">Megabyte (MB)</option>
+			<option value="Gigabyte">Gigabyte (GB)</option>
+		</select>
+	</div>
      
 </script>
 
 <script type="text/x-red" data-help-name="Memory">
-    <p>Use this node to query the system''s memory. </p> 
-    <p> Returns the total amount of system memory in bytes.
-    <p> Returns the amount of free system memory in bytes.</p>   
+    <p>Use this node to query the system's memory. </p> 
+    <p> Returns the total amount of system memory in bytes, kilobytes, megabytes or gigabytes.
+    <p> Returns the amount of free system memory in bytes, kilobytes, megabytes or gigabytes.</p>   
     <p> Returns the memory in use as a percentage. </p>    
 </script>
 
@@ -199,8 +208,9 @@
         category: 'Operating System',
         color:"#3FADB5",
         defaults: {
-            name: {value:""},                                       
-        },        
+            name: {value:""},
+            scale: {value:"Byte"},
+        },
         inputs:1,
         outputs:1,
         icon: "os.png",
@@ -217,7 +227,7 @@
     <div class="form-row">
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
-    </div>  
+    </div>
      
 </script>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "node-red-contrib-os",
+  "version": "0.1.7",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "loadavg-windows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/loadavg-windows/-/loadavg-windows-1.1.1.tgz",
+      "integrity": "sha512-ncSyH121LuN6OENPSohTAS2W85J3NYVIfjsVcK4spViQbHlQUXhGKd8VYhrqWyjtwwSTw4g3rrDraNoSJWRLgw==",
+      "requires": {
+        "weak-daemon": "1.0.3"
+      }
+    },
+    "node-disk-info": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-disk-info/-/node-disk-info-1.1.0.tgz",
+      "integrity": "sha512-ZVuZuWBJvogO4i5ABHmFzKPMHaypCWn6RqwK5xeyU3wFUtv9yUNJi2fZRQ4Mreplf81PK+sONdWLHVdzVJ64wg=="
+    },
+    "weak-daemon": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/weak-daemon/-/weak-daemon-1.0.3.tgz",
+      "integrity": "sha512-9OLYp5qQSxpnTIyuA1zJ7at3DV2DSBcbdXduC/3QFPeYjF30Lh1nfBrG+VLf4QUvZPz2lXFPu08oIRzWQfucVQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Node-Red nodes for obtaining cpu system information.",
   "main": "os/os.js",
   "dependencies": {
-    "node-df": "^0.1.1"
+    "node-disk-info": "^1.1.0",
+    "loadavg-windows": "^1.1.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-os",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Node-Red nodes for obtaining cpu system information.",
   "main": "os/os.js",
   "dependencies": {


### PR DESCRIPTION
Replace 'node-df' with 'node-disk-info', tested under Linux, Mac OS (untested on the new arm based Mac) and Windows (7 and 10).
Add 'loadavg-windows' to enable loadavg under windows environments.
Add the possibility to show memory information in byte, kilobyte, megabyte or gigabyte.